### PR TITLE
Before stripping html, add whitespace for excerpts

### DIFF
--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -13,10 +13,26 @@ var store = [
       {
         "title": {{ doc.title | jsonify }},
         "excerpt":
-        {%- if site.search_full_content == true -%}
-          {{ doc.content | strip_html | strip_newlines | jsonify }},
+          {%- if site.search_full_content == true -%}
+          {{ doc.content | 
+            replace:"</p>", " " | 
+            replace:"</h1>", " " | 
+            replace:"</h2>", " " | 
+            replace:"</h3>", " " | 
+            replace:"</h4>", " " | 
+            replace:"</h5>", " " | 
+            replace:"</h6>", " "|
+          strip_html | strip_newlines | jsonify }},
         {%- else -%}
-          {{ doc.content | strip_html | strip_newlines | truncatewords: 50 | jsonify }},
+          {{ doc.content | 
+            replace:"</p>", " " | 
+            replace:"</h1>", " " | 
+            replace:"</h2>", " " | 
+            replace:"</h3>", " " | 
+            replace:"</h4>", " " | 
+            replace:"</h5>", " " | 
+            replace:"</h6>", " "|
+           strip_html | strip_newlines | truncatewords: 50 | jsonify }},
         {%- endif -%}
         "categories": {{ doc.categories | jsonify }},
         "tags": {{ doc.tags | jsonify }},


### PR DESCRIPTION
When excerpts contain html that has implied whitespace (like a <h2> header followed by a <p>, but with no spaces in the text), add some whitespace *before* stripping the html, so that we see "Header paragraph" instead of "Headerparagraph" in the excerpt.